### PR TITLE
Feat: Add support for folia

### DIFF
--- a/src/main/java/me/dru/showcase/EventManager.java
+++ b/src/main/java/me/dru/showcase/EventManager.java
@@ -1,5 +1,6 @@
 package me.dru.showcase;
 
+import me.dru.showcase.utils.ScheduleUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -212,9 +213,12 @@ public class EventManager implements Listener {
 		Showcase.rotatesInstance.values().forEach(display->{
 			if(display==null||display.getItemDisplay()==null)
 				return;
-			Transformation transfom = display.getItemDisplay().getTransformation();
-			transfom.getLeftRotation().set(new AxisAngle4f( (float)Math.PI*rot*display.getAutoRotateSpeed(), new Vector3f(0, 1, 0)));
-			display.getItemDisplay().setTransformation(transfom);
+
+			ScheduleUtil.ENTITY.runTask(ModernShowcase.getInstance(), display.getItemDisplay(), () -> {
+				Transformation transfom = display.getItemDisplay().getTransformation();
+				transfom.getLeftRotation().set(new AxisAngle4f( (float)Math.PI*rot*display.getAutoRotateSpeed(), new Vector3f(0, 1, 0)));
+				display.getItemDisplay().setTransformation(transfom);
+			});
 		});
 	}
 }

--- a/src/main/java/me/dru/showcase/ModernShowcase.java
+++ b/src/main/java/me/dru/showcase/ModernShowcase.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import me.dru.showcase.utils.ScheduleUtil;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -41,7 +42,7 @@ public class ModernShowcase extends JavaPlugin {
 		registerCrafting();
 		registerBstats();
 		GUILib.register(this);
-		Bukkit.getScheduler().runTaskTimer(instance, ()->EventManager.rotate(), 2, 2);
+		ScheduleUtil.GLOBAL.runTaskTimer(instance, ()-> EventManager.rotate(), 2, 2);
 		Bukkit.getLogger().info("ModernShowcase is enabled.");
 		
 	}

--- a/src/main/java/me/dru/showcase/block/Showcase.java
+++ b/src/main/java/me/dru/showcase/block/Showcase.java
@@ -133,7 +133,7 @@ public class Showcase {
 		Location loc =  item.getLocation();
 		loc.setYaw(x);
 		loc.setPitch(y);
-		item.teleport(loc);
+		item.teleportAsync(loc);
 		PersistentDataContainer con = getDataContainer();
 		con.set(spacedKey(block,"rotX"), PersistentDataType.FLOAT, x);
 		con.set(spacedKey(block,"rotY"), PersistentDataType.FLOAT, y);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: ModernShowcase
 main: me.dru.showcase.ModernShowcase
 version: 1.3
+folia-supported: true
 description: "A good showcase plugin"
 author: Dru_TNT
 softdepend: [CoreProtect]


### PR DESCRIPTION
## Description

- This pull request add support for Folia (and its fork)
- Tested with Luminol 1.20.4, Paper 1.19.4

- - -

This commit add a class "ScheduleUtil" used for support Folia's new scheduler api without breaking backward compatibility like 1.19 - 1.20.3, 
Another changes is we use the teleportAsync instead of teleport in setRotation(float, float) method.